### PR TITLE
paginação do scraper (ceil) e marcação de páginas concluídas

### DIFF
--- a/backend/crates/scraper/src/scraper.rs
+++ b/backend/crates/scraper/src/scraper.rs
@@ -89,7 +89,8 @@ pub async fn scrape(store: impl store::Store + 'static) {
             );
 
             if let Ok(mut total_pages) = total_pages.lock() {
-                let new_total_pages = response.total / MAX_PAGE_SIZE;
+                // use ceil division to ensure the last (incomplete) page is accounted for
+                let new_total_pages = (response.total + MAX_PAGE_SIZE - 1) / MAX_PAGE_SIZE;
                 if total_pages.is_none_or(|total_pages| total_pages < new_total_pages) {
                     *total_pages = Some(new_total_pages);
                 }

--- a/backend/crates/scraper/src/store/meilisearch.rs
+++ b/backend/crates/scraper/src/store/meilisearch.rs
@@ -117,9 +117,8 @@ impl Store for MeilisearchStore {
             }
         }
 
-        if contracts.len() == contracts_per_page {
-            self.save_page_as_completed(page)?;
-        }
+        // Mark page as completed regardless of being full or the final partial page
+        self.save_page_as_completed(page)?;
 
         Ok(())
     }


### PR DESCRIPTION
Corrige total_pages com ceil e marca a página como concluída após guardar (inclui a última parcial), evitando lacunas de ingestão e re-fetch infinito; sem breaking changes; alinhado com funcionalidades planeadas do README